### PR TITLE
Select authors from a sorted array

### DIFF
--- a/lib/git/duo/author_collection.rb
+++ b/lib/git/duo/author_collection.rb
@@ -12,7 +12,9 @@ module Git
         result += opts.
           select {|k, _| authors.sample.respond_to? k }.
           map {|k, v|
-            authors.select {|o| o.send(k) =~ /#{v}/i }
+            authors.
+              sort_by(&:key).
+              select {|o| o.send(k) =~ /#{v}/i }
           }.flatten
       rescue NoMethodError
         result

--- a/test/git/duo/author_collection_test.rb
+++ b/test/git/duo/author_collection_test.rb
@@ -21,6 +21,16 @@ module Git::Duo
       assert_equal "Alfred Pennyworth", result.name
     end
 
+    def test_where_partial_matches_closest
+      collection = AuthorCollection.new alexander_and_al
+
+      search = collection.where(key: 'al')
+      result = search.first
+
+      refute_predicate search, :empty?
+      assert_equal "Alfred Pennyworth", result.name
+    end
+
     def test_where_with_nonexisting_keys
       assert_empty collection.where(omg: 0)
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,13 @@ def jim_and_harvey
   ]
 end
 
+def alexander_and_al
+  [
+    Git::Duo::Author.import('alexander Alexander Knox <alexander@gotham.travel>'),
+    Git::Duo::Author.import('al Alfred Pennyworth <alfred@gotham.travel>')
+  ]
+end
+
 class DummyWrapper < Struct.new(:directory)
   def config(*)
     git_config


### PR DESCRIPTION
Since `git-duo` allows for partial matching, I was running into some
issues where it would select another user than the one I intended.

Consider having a configuration like this:
```
[git-duo]
  andreas = Andreas <andreas@example.com>
  andre = André <andre@example.com>
  emil = Emil <emil@example.com>
```

If you ran `git duo andre emil`, it would select Andreas and Emil since
the key `andreas` was listed before `andre` in the configuration.

This code sorts the list of authors before filtering down the list of
authors to resolve that issue.