### PR TITLE
Support changing authors inside a subdirectory

### DIFF
--- a/lib/git/duo/cli.rb
+++ b/lib/git/duo/cli.rb
@@ -51,6 +51,8 @@ module Git
         abort "missing required argument\n\n #{parser.help}"
       rescue Git::Duo::EmailNotImplementedError
         abort "`Email format isn't set, see -h on how to set the email format"
+      rescue Git::Duo::NotAGitRepository
+        exit 1
       end
 
       private

--- a/lib/git/duo/exceptions.rb
+++ b/lib/git/duo/exceptions.rb
@@ -1,5 +1,6 @@
 module Git
   module Duo
     EmailNotImplementedError = Class.new StandardError
+    NotAGitRepository = Class.new StandardError
   end
 end

--- a/lib/git/duo/repo.rb
+++ b/lib/git/duo/repo.rb
@@ -5,7 +5,7 @@ module Git
   module Duo
     class Repo
       def self.current
-        new Dir.pwd
+        new Wrapper.top_level
       end
 
       attr_reader :directory, :wrapper

--- a/lib/git/duo/wrapper.rb
+++ b/lib/git/duo/wrapper.rb
@@ -3,6 +3,12 @@ module Git
     class Wrapper
       PIPE_STDOUT_TO_STDERR = '2>&1'
 
+      def self.top_level
+        directory = `git rev-parse --show-toplevel`.strip
+        raise NotAGitRepository unless $?.exitstatus.zero?
+        directory
+      end
+
       def initialize(directory)
         @directory = directory
       end

--- a/test/git/duo/repo_test.rb
+++ b/test/git/duo/repo_test.rb
@@ -9,10 +9,13 @@ module Git::Duo
     attr_reader :repo, :wrapper
 
     def test_current_inits_repo_with_current_dir
-      repo = Repo.current
       expected = Dir.pwd
 
-      assert_equal expected, repo.directory
+      Dir.chdir('test') do
+        repo = Repo.current
+
+        assert_equal expected, repo.directory
+      end
     end
 
     def test_initialize_expands_directory_path

--- a/test/git/duo/wrapper_test.rb
+++ b/test/git/duo/wrapper_test.rb
@@ -1,0 +1,20 @@
+require_relative '../../test_helper'
+
+module Git
+  module Duo
+    class WrapperTest < MiniTest::Test
+      def test_top_level
+        directory = Wrapper.top_level
+
+        expected_directory = File.expand_path('../../../../', __FILE__)
+        assert_equal expected_directory, directory
+      end
+
+      def test_top_level_when_not_in_git
+        assert_raises NotAGitRepository do
+          Dir.chdir('/tmp') { Wrapper.top_level }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Support calling `Git::Duo::Repo.current` outside a git repository, and
handle that error gracefully.