### PR TITLE
Deprecate Ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
+  - 2.1.10
+  - 2.2.6
+  - 2.3.1
 notifications:
   email: false


### PR DESCRIPTION
This breakage warrants a 2.0 release.